### PR TITLE
use hashlib.md5 instead of md5, if possible

### DIFF
--- a/chinese/upgrade.py
+++ b/chinese/upgrade.py
@@ -1,16 +1,19 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright © 2012-2014 Thomas TEMPÉ, <thomas.tempe@alysse.org>
-# 
+#
 # License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
 #
 import os, sys, os.path
-import  md5
+try:
+    from hashlib import  md5
+except:
+    import  md5
 from aqt import mw
 from aqt.utils import askUser, isWin, showInfo
 from aqt.downloader import download
 
-from config import chinese_support_config 
+from config import chinese_support_config
 from __init__ import __version__
 
 older_versions = ['\xb8\xd2\x9e\x073\x8f\xad\xf6\xe2cip\xdd\xe9;\xa2',


### PR DESCRIPTION
md5 is deprecated, it should be hashlib.md5 instead. This pull requests changes the code accordingly by trying to import hashlib.md5 first. Works at least with Python 2.6 and 2.7.

Enjoy!
